### PR TITLE
Update .travis.yaml to download ballerina installer in Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,16 @@ services:
 cache:
   directories:
     - .autoconf
-    - $HOME/.m2
+    - ${HOME}/.m2
 before_install:
+  - wget https://product-dist.ballerina.io/downloads/0.990.3/ballerina-linux-installer-x64-0.990.3.deb
+  - sudo dpkg -i ballerina*.deb
   - wget https://wso2.org/jenkins/view/cellery/job/cellery/job/sdk/lastSuccessfulBuild/artifact/installers/ubuntu-x64/target/*zip*/target.zip
   - unzip target.zip
-  - sudo dpkg -i target/*.deb
+  - sudo dpkg -i target/cellery*.deb
   - npm i -g npm
-  - mkdir -p $HOME/gopath/src/github.com/cellery-io
-  - mv ${TRAVIS_BUILD_DIR} $GOPATH/src/github.com/cellery-io/samples
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/cellery-io/samples
-  - cd $HOME/gopath/src/github.com/cellery-io/samples
+  - mkdir -p ${GOPATH}/src/github.com/cellery-io
+  - mv ${TRAVIS_BUILD_DIR} ${GOPATH}/src/github.com/cellery-io/samples
+  - export TRAVIS_BUILD_DIR=${GOPATH}/src/github.com/cellery-io/samples
+  - cd ${GOPATH}/src/github.com/cellery-io/samples
 script: make clean check-style build docker cellery-build


### PR DESCRIPTION
## Purpose
> Travis builds were failing in the Docker based CLI approach. This needs to be avoided.

## Goals
> To avoid this failure in the Travis Build, ballerina was installed as a step before the build.

## Approach
> The ballerina installer is downloaded from ballerina and installed as a step before the build.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A