### PR TITLE
Update Pet Store Add To Cart popup to allow erasing the input field completely

### DIFF
--- a/pet-store/pet-fe/components/portal/src/components/catalog/AddToCartPopup.jsx
+++ b/pet-store/pet-fe/components/portal/src/components/catalog/AddToCartPopup.jsx
@@ -45,6 +45,7 @@ class AddToCartPopup extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            addToCartEnabled: true,
             amount: 1,
             notification: {
                 open: false,
@@ -62,13 +63,22 @@ class AddToCartPopup extends React.Component {
         });
     };
 
-    handleAmountChange = () => {
+    handleAmountChange = (event) => {
         const {item} = this.props;
-        const value = parseInt(event.target.value, 10);
-        if (value > 0 && value <= item.inStock) {
+        const elementValue = event.currentTarget.value;
+        if (elementValue === "") {
             this.setState({
-                amount: value
+                amount: "",
+                addToCartEnabled: false
             });
+        } else {
+            const value = parseInt(elementValue, 10);
+            if (value > 0 && value <= item.inStock) {
+                this.setState({
+                    amount: value,
+                    addToCartEnabled: true
+                });
+            }
         }
     };
 
@@ -87,7 +97,7 @@ class AddToCartPopup extends React.Component {
 
     render() {
         const {classes, item, onClose, open} = this.props;
-        const {amount, notification} = this.state;
+        const {addToCartEnabled, amount, notification} = this.state;
         return (
             <React.Fragment>
                 <Dialog maxWidth={"sm"} open={open} onClose={onClose} TransitionComponent={Zoom}
@@ -129,8 +139,8 @@ class AddToCartPopup extends React.Component {
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={onClose} size={"small"}>Cancel</Button>
-                        <Button disabled={amount === 0} variant={"contained"} color={"primary"} size={"small"}
-                            onClick={this.handleAddToCart}>
+                        <Button disabled={amount === 0 || !addToCartEnabled} variant={"contained"}
+                            color={"primary"} size={"small"} onClick={this.handleAddToCart}>
                             <Check/> Add to Cart
                         </Button>
                     </DialogActions>


### PR DESCRIPTION
## Purpose
> Allow the user to completely empty the amount input in the add to cart popup in the petstore.

## Goals
> Allow the user to completely empty the amount input in the add to cart popup in the petstore.

## Approach
> Empty input field is allowed with a disabled add to cart button.

## User stories
> As a user, I need to completely empty the field to type in a value I prefer.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A